### PR TITLE
Triggering pr's again, need to add labels before opening PR. Even if …

### DIFF
--- a/.github/workflows/auto-merge-prod.yml
+++ b/.github/workflows/auto-merge-prod.yml
@@ -105,7 +105,7 @@ jobs:
 
 
 
-      # Does this now merge correctly? v2
+      # Does this now merge correctly? v3
 
       ##### MATRIX SETUP, removed while testing sequential aproch
       # # Setup Git:


### PR DESCRIPTION
…you add them after, the 'waitFor' action still sees the failed attempt for checking for labels, and freaks out