### PR TITLE
Fixes polygon Counter-clockwise CMR error check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ------
 
+## [1.1.6](https://github.com/asfadmin/Discovery-WKTUtils/compare/v1.1.5...v1.1.6)
+
+### Fixed
+- Fixes clockwise polygon repair failing due to updated CMR error message
+
+------
+
 ## [1.1.5](https://github.com/asfadmin/Discovery-WKTUtils/compare/v1.1.4...v1.1.5)
 
 ### Removed

--- a/WKTUtils/RepairWKT.py
+++ b/WKTUtils/RepairWKT.py
@@ -562,7 +562,7 @@ class simplifyWKT():
         cmr_coords = parse_wkt_util(wkt.dumps(wkt_obj_wrapped)).split(':')[1].split(',')
         status_code, text = CMRSendRequest(cmr_coords)
         if status_code != 200:
-            if 'Please check the order of your points.' in text:
+            if 'Points must be provided in counter-clockwise order.' in text:
                 it = iter(cmr_coords)
                 rev = reversed(list(zip(it, it)))
                 reversed_coords = [i for sub in rev for i in sub]


### PR DESCRIPTION
## [1.1.6](https://github.com/asfadmin/Discovery-WKTUtils/compare/v1.1.5...v1.1.6)

### Fixed
- Fixes clockwise polygon repair failing due to updated CMR error message

------

